### PR TITLE
Run supervisord with pid 1

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 sh /generate_mitm_ca.sh
-supervisord -c /supervisord.conf
+exec supervisord -c /supervisord.conf


### PR DESCRIPTION
Hello,

this pull request makes sure to avoid the PID 1 zombie reaping problem with docker.

The change makes sure that the supervisord process uses the PID 1 after the initial setup of the mitm certificates.

This should mainly be a qol change, but is generally seen as better practice with containers.

Kind regards,
Luke